### PR TITLE
Update sobol_seq.py

### DIFF
--- a/sobol_seq/sobol_seq.py
+++ b/sobol_seq/sobol_seq.py
@@ -124,7 +124,7 @@ def i4_sobol_generate(dim_num, n, skip=1):
     """
     r = np.full((n, dim_num), np.nan)
     for j in range(n):
-        seed = j + 1
+        seed = j + skip
         r[j, 0:dim_num], next_seed = i4_sobol(dim_num, seed)
 
     return r
@@ -142,7 +142,7 @@ def i4_sobol_generate_std_normal(dim_num, n, skip=1):
       Output, real np array of shape (n, dim_num).
     """
 
-    sobols = i4_sobol_generate(dim_num, n, skip=1)
+    sobols = i4_sobol_generate(dim_num, n, skip)
 
     normals = norm.ppf(sobols)
 


### PR DESCRIPTION
I made changes to both i4_sobol_generate() and to i4_sobol_generate_std_normal(). In both functions the skip argument was ignored as far as I can tell, resulting in identical sobol sequences for any skip/seed input.
