### PR TITLE
Add the "scipy" and "numpy" packages as dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,8 @@ setup(name='sobol_seq',
       author_email='naught101@gmail.com',
       license='MIT',
       packages=['sobol_seq'],
+      install_requires=[
+          'scipy',
+          'numpy'
+      ],
       zip_safe=False)


### PR DESCRIPTION
By specifying the dependencies of a package we allow the user to install
"sobol_seq" with a single `pip install` command, even in a clean environment.